### PR TITLE
webhook extensions are working

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -101,6 +101,12 @@ public class WorkflowDef extends BaseDef {
     @ProtoField(id = 15)
     private Map<String, Object> inputTemplate = new HashMap<>();
 
+    @ProtoField(id = 16)
+    private String webhookUrl;
+
+    @ProtoField(id = 17)
+    private String webhookAuthToken;
+
     /**
      * @return the name
      */
@@ -305,6 +311,34 @@ public class WorkflowDef extends BaseDef {
         this.variables = variables;
     }
 
+    /**
+     * @return the webhookUrl
+     */
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    /**
+     * @param webhookUrl the webhookUrl to set
+     */
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    /**
+     * @return the webhookAuthToken
+     */
+    public String getWebhookAuthToken() {
+        return webhookAuthToken;
+    }
+
+    /**
+     * @param webhookAuthToken the webhookAuthToken to set
+     */
+    public void setWebhookAuthToken(String webhookAuthToken) {
+        this.webhookAuthToken = webhookAuthToken;
+    }
+
     public Map<String, Object> getInputTemplate() {
         return inputTemplate;
     }
@@ -393,7 +427,9 @@ public class WorkflowDef extends BaseDef {
                 && Objects.equals(getOutputParameters(), that.getOutputParameters())
                 && Objects.equals(getFailureWorkflow(), that.getFailureWorkflow())
                 && Objects.equals(getOwnerEmail(), that.getOwnerEmail())
-                && Objects.equals(getTimeoutSeconds(), that.getTimeoutSeconds());
+                && Objects.equals(getTimeoutSeconds(), that.getTimeoutSeconds())
+                && Objects.equals(getWebhookUrl(), that.getWebhookUrl())
+                && Objects.equals(getWebhookAuthToken(), that.getWebhookAuthToken());
     }
 
     @Override
@@ -408,7 +444,9 @@ public class WorkflowDef extends BaseDef {
                 getFailureWorkflow(),
                 getSchemaVersion(),
                 getOwnerEmail(),
-                getTimeoutSeconds());
+                getTimeoutSeconds(),
+                getWebhookUrl(),
+                getWebhookAuthToken());
     }
 
     @Override
@@ -439,6 +477,10 @@ public class WorkflowDef extends BaseDef {
                 + workflowStatusListenerEnabled
                 + ", timeoutSeconds="
                 + timeoutSeconds
+                + ", webhookUrl="
+                + webhookUrl
+                + ", webhookAuthToken="
+                + webhookAuthToken
                 + '}';
     }
 }

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java
@@ -69,6 +69,10 @@ public class ConductorWorkflow<T> {
 
     private final WorkflowExecutor workflowExecutor;
 
+    private String webhookUrl;
+
+    private String webhookAuthToken;
+
     public ConductorWorkflow(WorkflowExecutor workflowExecutor) {
         this.workflowOutput = new HashMap<>();
         this.workflowExecutor = workflowExecutor;
@@ -167,6 +171,22 @@ public class ConductorWorkflow<T> {
         this.variables = variables;
     }
 
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public String getWebhookAuthToken() {
+        return webhookAuthToken;
+    }
+
+    public void setWebhookAuthToken(String webhookAuthToken) {
+        this.webhookAuthToken = webhookAuthToken;
+    }
+
     /**
      * Execute a dynamic workflow without creating a definition in metadata store.
      *
@@ -254,6 +274,8 @@ public class ConductorWorkflow<T> {
         def.setOutputParameters(workflowOutput);
         def.setVariables(variables);
         def.setInputTemplate(objectMapper.convertValue(defaultInput, Map.class));
+        def.setWebhookUrl(webhookUrl);
+        def.setWebhookAuthToken(webhookAuthToken);
 
         for (Task task : tasks) {
             def.getTasks().addAll(task.getWorkflowDefTasks());

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java
@@ -55,6 +55,10 @@ public class WorkflowBuilder<T> {
 
     private WorkflowExecutor workflowExecutor;
 
+    private String webhookUrl;
+
+    private String webhookAuthToken;
+
     public final InputOutputGetter input =
             new InputOutputGetter("workflow", InputOutputGetter.Field.input);
 
@@ -123,6 +127,16 @@ public class WorkflowBuilder<T> {
         return this;
     }
 
+    public WorkflowBuilder<T> withWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+        return this;
+    }
+
+    public WorkflowBuilder<T> withWebhookAuthToken(String webhookAuthToken) {
+        this.webhookAuthToken = webhookAuthToken;
+        return this;
+    }
+
     public WorkflowBuilder<T> output(String key, boolean value) {
         output.put(key, value);
         return this;
@@ -168,6 +182,8 @@ public class WorkflowBuilder<T> {
         workflow.setDefaultInput(defaultInput);
         workflow.setWorkflowOutput(output);
         workflow.setVariables(state);
+        workflow.setWebhookUrl(webhookUrl);
+        workflow.setWebhookAuthToken(webhookAuthToken);
 
         for (Task task : tasks) {
             workflow.add(task);


### PR DESCRIPTION
Pull Request type
----
- [ ] Feature

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
I added webhook variable definitions to common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java,
java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java,
java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java

With the use of HTTP tasks in a workflow definition, I can send workflow notifications to a webhook and customize the variables sent to the webhook. Using this method, there is no event listener specifically for webhooks, which also utilizes the existing capabilities of Conductor to utilize HTTP protocols. I believe that this is infinitely scalable as a result as the webhook notifications are defined directly as a task within a workflow. An example workflow is show below with webhook notifications. Please note that you can provide a webhookAuthToken as well if your webhook requires it.
[example_wf_with_webhooks.json](https://github.com/UofL-BACS-Conductor-Capstone-Team-1/conductor-webhook-extensions/files/14319642/example_wf_with_webhooks.json)

Alternatives considered
----

_Describe alternative implementation you have considered_
