### PR TITLE
Feature: Webhooks for Workflow and Task Statuses (REVIEW PR)

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -101,6 +101,12 @@ public class WorkflowDef extends BaseDef {
     @ProtoField(id = 15)
     private Map<String, Object> inputTemplate = new HashMap<>();
 
+    @ProtoField(id = 16)
+    private String webhookUrl;
+
+    @ProtoField(id = 17)
+    private String webhookAuthToken;
+
     /**
      * @return the name
      */
@@ -305,6 +311,34 @@ public class WorkflowDef extends BaseDef {
         this.variables = variables;
     }
 
+    /**
+     * @return the webhookUrl
+     */
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    /**
+     * @param webhookUrl the webhookUrl to set
+     */
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    /**
+     * @return the webhookAuthToken
+     */
+    public String getWebhookAuthToken() {
+        return webhookAuthToken;
+    }
+
+    /**
+     * @param webhookAuthToken the webhookAuthToken to set
+     */
+    public void setWebhookAuthToken(String webhookAuthToken) {
+        this.webhookAuthToken = webhookAuthToken;
+    }
+
     public Map<String, Object> getInputTemplate() {
         return inputTemplate;
     }
@@ -393,7 +427,9 @@ public class WorkflowDef extends BaseDef {
                 && Objects.equals(getOutputParameters(), that.getOutputParameters())
                 && Objects.equals(getFailureWorkflow(), that.getFailureWorkflow())
                 && Objects.equals(getOwnerEmail(), that.getOwnerEmail())
-                && Objects.equals(getTimeoutSeconds(), that.getTimeoutSeconds());
+                && Objects.equals(getTimeoutSeconds(), that.getTimeoutSeconds())
+                && Objects.equals(getWebhookUrl(), that.getWebhookUrl())
+                && Objects.equals(getWebhookAuthToken(), that.getWebhookAuthToken());
     }
 
     @Override
@@ -408,7 +444,9 @@ public class WorkflowDef extends BaseDef {
                 getFailureWorkflow(),
                 getSchemaVersion(),
                 getOwnerEmail(),
-                getTimeoutSeconds());
+                getTimeoutSeconds(),
+                getWebhookUrl(),
+                getWebhookAuthToken());
     }
 
     @Override
@@ -439,6 +477,10 @@ public class WorkflowDef extends BaseDef {
                 + workflowStatusListenerEnabled
                 + ", timeoutSeconds="
                 + timeoutSeconds
+                + ", webhookUrl="
+                + webhookUrl
+                + ", webhookAuthToken="
+                + webhookAuthToken
                 + '}';
     }
 }

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1124,6 +1124,12 @@ public abstract class AbstractProtoMapper {
         for (Map.Entry<String, Object> pair : from.getInputTemplate().entrySet()) {
             to.putInputTemplate( pair.getKey(), toProto( pair.getValue() ) );
         }
+        if (from.getWebhookUrl() != null) {
+            to.setWebhookUrl( from.getWebhookUrl() );
+        }
+        if (from.getWebhookAuthToken() != null) {
+            to.setWebhookAuthToken( from.getWebhookAuthToken() );
+        }
         return to.build();
     }
 
@@ -1156,6 +1162,8 @@ public abstract class AbstractProtoMapper {
             inputTemplateMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setInputTemplate(inputTemplateMap);
+        to.setWebhookUrl( from.getWebhookUrl() );
+        to.setWebhookAuthToken( from.getWebhookAuthToken() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflowdef.proto
+++ b/grpc/src/main/proto/model/workflowdef.proto
@@ -28,4 +28,6 @@ message WorkflowDef {
     int64 timeout_seconds = 13;
     map<string, google.protobuf.Value> variables = 14;
     map<string, google.protobuf.Value> input_template = 15;
+    string webhook_url = 16;
+    string webhook_auth_token = 17;
 }

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java
@@ -69,6 +69,10 @@ public class ConductorWorkflow<T> {
 
     private final WorkflowExecutor workflowExecutor;
 
+    private String webhookUrl;
+
+    private String webhookAuthToken;
+
     public ConductorWorkflow(WorkflowExecutor workflowExecutor) {
         this.workflowOutput = new HashMap<>();
         this.workflowExecutor = workflowExecutor;
@@ -167,6 +171,22 @@ public class ConductorWorkflow<T> {
         this.variables = variables;
     }
 
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    public void setWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public String getWebhookAuthToken() {
+        return webhookAuthToken;
+    }
+
+    public void setWebhookAuthToken(String webhookAuthToken) {
+        this.webhookAuthToken = webhookAuthToken;
+    }
+
     /**
      * Execute a dynamic workflow without creating a definition in metadata store.
      *
@@ -254,6 +274,8 @@ public class ConductorWorkflow<T> {
         def.setOutputParameters(workflowOutput);
         def.setVariables(variables);
         def.setInputTemplate(objectMapper.convertValue(defaultInput, Map.class));
+        def.setWebhookUrl(webhookUrl);
+        def.setWebhookAuthToken(webhookAuthToken);
 
         for (Task task : tasks) {
             def.getTasks().addAll(task.getWorkflowDefTasks());

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java
@@ -55,6 +55,10 @@ public class WorkflowBuilder<T> {
 
     private WorkflowExecutor workflowExecutor;
 
+    private String webhookUrl;
+
+    private String webhookAuthToken;
+
     public final InputOutputGetter input =
             new InputOutputGetter("workflow", InputOutputGetter.Field.input);
 
@@ -123,6 +127,16 @@ public class WorkflowBuilder<T> {
         return this;
     }
 
+    public WorkflowBuilder<T> withWebhookUrl(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+        return this;
+    }
+
+    public WorkflowBuilder<T> withWebhookAuthToken(String webhookAuthToken) {
+        this.webhookAuthToken = webhookAuthToken;
+        return this;
+    }
+
     public WorkflowBuilder<T> output(String key, boolean value) {
         output.put(key, value);
         return this;
@@ -168,6 +182,8 @@ public class WorkflowBuilder<T> {
         workflow.setDefaultInput(defaultInput);
         workflow.setWorkflowOutput(output);
         workflow.setVariables(state);
+        workflow.setWebhookUrl(webhookUrl);
+        workflow.setWebhookAuthToken(webhookAuthToken);
 
         for (Task task : tasks) {
             workflow.add(task);

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -130,3 +130,28 @@ management.datadog.metrics.export.enabled=false
 # management.datadog.metrics.export.apiKey=YOUR_API_KEY
 # management.datadog.metrics.export.uri=dd instance URL
 # management.datadog.metrics.export.step=10s
+
+# To enable webhook module for TaskStatus and WorkflowStatus notifications
+conductor.workflow-status-listener.type=workflow_publisher
+conductor.task-status-listener.type=task_publisher
+
+# To enable Workflow/Task Summary Input/Output JSON Serialization, use the following:
+conductor.app.summary-input-output-json-serialization.enabled=true
+
+# Webhook Push notification properties
+conductor.status-notifier.notification.url=
+conductor.status-notifier.notification.endpointWorkflow=
+conductor.status-notifier.notification.endpointTask=
+# Use enums in TaskModel.Status
+conductor.status-notifier.notification.subscribedTaskStatuses=SCHEDULED
+conductor.status-notifier.notification.headerDomainGroup=
+conductor.status-notifier.notification.headerAccountCookie=
+conductor.status-notifier.notification.headerPrefer=
+conductor.status-notifier.notification.headerPreferValue=
+conductor.status-notifier.notification.requestTimeoutMsConnect=100
+conductor.status-notifier.notification.requestTimeoutMsRead=300
+conductor.status-notifier.notification.requestTimeoutMsConnMgr=300
+conductor.status-notifier.notification.requestRetryCount=3
+conductor.status-notifier.notification.requestRetryIntervalMs=50
+conductor.status-notifier.notification.connectionPoolMaxRequest=3
+conductor.status-notifier.notification.connectionPoolMaxRequestPerRoute=3

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,6 +62,7 @@ include 'java-sdk'
 
 // community modules
 include 'workflow-event-listener'
+include 'task-status-listener'
 include 'test-util'
 include 'kafka'
 include 'common-persistence'

--- a/task-status-listener/build.gradle
+++ b/task-status-listener/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     implementation project(':conductor-common')
     implementation project(':conductor-core')
     implementation project(':conductor-redis-persistence')
-    implementation project(':conductor-task-status-listener')
     implementation project(':conductor-annotations')
 
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
@@ -16,18 +15,10 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
 
-    testImplementation project(':conductor-server')
-    testImplementation "org.apache.groovy:groovy-all:${revGroovy}"
-    testImplementation "org.spockframework:spock-core:${revSpock}"
-    testImplementation "org.spockframework:spock-spring:${revSpock}"
     implementation "org.springframework.boot:spring-boot-starter-log4j2"
-    testImplementation 'org.springframework.retry:spring-retry'
-    testImplementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation "com.netflix.dyno-queues:dyno-queues-redis:${revDynoQueues}"
     testImplementation project(':conductor-test-util').sourceSets.test.output
 
     //In memory
     implementation "org.rarefiedredis.redis:redis-java:${revRarefiedRedis}"
-    testImplementation "redis.clients:jedis:${revJedis}"
 
 }

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/RestClientManager.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/RestClientManager.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.SocketException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RestClientManager {
+    private static final Logger logger = LoggerFactory.getLogger(RestClientManager.class);
+    private StatusNotifierNotificationProperties config;
+    private CloseableHttpClient client;
+    private String notifType;
+    private String notifId;
+
+    public enum NotificationType {
+        TASK,
+        WORKFLOW
+    };
+
+    public RestClientManager(StatusNotifierNotificationProperties config) {
+        logger.info("created RestClientManager" + System.currentTimeMillis());
+        this.config = config;
+        this.client = prepareClient();
+    }
+
+    private PoolingHttpClientConnectionManager prepareConnManager() {
+        PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+        connManager.setMaxTotal(config.getConnectionPoolMaxRequest());
+        connManager.setDefaultMaxPerRoute(config.getConnectionPoolMaxRequestPerRoute());
+        return connManager;
+    }
+
+    private RequestConfig prepareRequestConfig() {
+        return RequestConfig.custom()
+                // The time to establish the connection with the remote host
+                // [http.connection.timeout].
+                // Responsible for java.net.SocketTimeoutException: connect timed out.
+                .setConnectTimeout(config.getRequestTimeOutMsConnect())
+
+                // The time waiting for data after the connection was established
+                // [http.socket.timeout]. The maximum time
+                // of inactivity between two data packets. Responsible for
+                // java.net.SocketTimeoutException: Read timed out.
+                .setSocketTimeout(config.getRequestTimeoutMsread())
+
+                // The time to wait for a connection from the connection manager/pool
+                // [http.connection-manager.timeout].
+                // Responsible for org.apache.http.conn.ConnectionPoolTimeoutException.
+                .setConnectionRequestTimeout(config.getRequestTimeoutMsConnMgr())
+                .build();
+    }
+
+    /**
+     * Custom HttpRequestRetryHandler implementation to customize retries for different IOException
+     */
+    private class CustomHttpRequestRetryHandler implements HttpRequestRetryHandler {
+        int maxRetriesCount = config.getRequestRetryCount();
+        int retryIntervalInMilisec = config.getRequestRetryCountIntervalMs();
+
+        /**
+         * Triggered only in case of exception
+         *
+         * @param exception The cause
+         * @param executionCount Retry attempt sequence number
+         * @param context {@link HttpContext}
+         * @return True if we want to retry request, false otherwise
+         */
+        public boolean retryRequest(
+                IOException exception, int executionCount, HttpContext context) {
+            Throwable rootCause = ExceptionUtils.getRootCause(exception);
+            logger.warn(
+                    "Retrying {} notification. Id: {}, root cause: {}",
+                    notifType,
+                    notifId,
+                    rootCause.toString());
+
+            if (executionCount >= maxRetriesCount) {
+                logger.warn(
+                        "{} notification failed after {} retries. Id: {} .",
+                        notifType,
+                        executionCount,
+                        notifId);
+                return false;
+            } else if (rootCause instanceof SocketException
+                    || rootCause instanceof InterruptedIOException
+                    || exception instanceof SSLException) {
+                try {
+                    Thread.sleep(retryIntervalInMilisec);
+                } catch (InterruptedException e) {
+                    e.printStackTrace(); // do nothing
+                }
+                return true;
+            } else return false;
+        }
+    }
+
+    /**
+     * Custom ServiceUnavailableRetryStrategy implementation to retry on HTTP 503 (= service
+     * unavailable)
+     */
+    private class CustomServiceUnavailableRetryStrategy implements ServiceUnavailableRetryStrategy {
+        int maxRetriesCount = config.getRequestRetryCount();
+        int retryIntervalInMilisec = config.getRequestRetryCountIntervalMs();
+
+        @Override
+        public boolean retryRequest(
+                final HttpResponse response, final int executionCount, final HttpContext context) {
+
+            int httpStatusCode = response.getStatusLine().getStatusCode();
+            if (httpStatusCode != 503) return false; // retry only on HTTP 503
+
+            if (executionCount >= maxRetriesCount) {
+                logger.warn(
+                        "HTTP 503 error. {} notification failed after {} retries. Id: {} .",
+                        notifType,
+                        executionCount,
+                        notifId);
+                return false;
+            } else {
+                logger.warn(
+                        "HTTP 503 error. {} notification failed after {} retries. Id: {} .",
+                        notifType,
+                        executionCount,
+                        notifId);
+                return true;
+            }
+        }
+
+        @Override
+        public long getRetryInterval() {
+            // Retry interval between subsequent requests, in milliseconds.
+            // If not set, the default value is 1000 milliseconds.
+            return retryIntervalInMilisec;
+        }
+    }
+
+    // By default retries 3 times
+    private CloseableHttpClient prepareClient() {
+        return HttpClients.custom()
+                .setConnectionManager(prepareConnManager())
+                .setDefaultRequestConfig(prepareRequestConfig())
+                .setRetryHandler(new CustomHttpRequestRetryHandler())
+                .setServiceUnavailableRetryStrategy(new CustomServiceUnavailableRetryStrategy())
+                .build();
+    }
+
+    public void postNotification(
+            RestClientManager.NotificationType notifType,
+            String data,
+            String id,
+            StatusNotifier statusNotifier)
+            throws IOException {
+        this.notifType = notifType.toString();
+        notifId = id;
+        String url = prepareUrl(notifType, statusNotifier);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(config.getHeaderPrefer(), config.getHeaderPreferValue());
+
+        HttpPost request = createPostRequest(url, data, headers);
+        long start = System.currentTimeMillis();
+        executePost(request);
+        long duration = System.currentTimeMillis() - start;
+        if (duration > 100) {
+            logger.info("Round trip response time = " + (duration) + " millis");
+        }
+    }
+
+    private String prepareUrl(
+            RestClientManager.NotificationType notifType, StatusNotifier statusNotifier) {
+        String urlEndPoint = "";
+
+        if (notifType == RestClientManager.NotificationType.TASK) {
+            if (statusNotifier != null
+                    && StringUtils.isNotBlank(statusNotifier.getEndpointTask())) {
+                urlEndPoint = statusNotifier.getEndpointTask();
+            } else {
+                urlEndPoint = config.getEndpointTask();
+            }
+        } else if (notifType == RestClientManager.NotificationType.WORKFLOW) {
+            if (statusNotifier != null
+                    && StringUtils.isNotBlank(statusNotifier.getEndpointTask())) {
+                urlEndPoint = statusNotifier.getEndpointWorkflow();
+            } else {
+                urlEndPoint = config.getEndpointWorkflow();
+            }
+        }
+        String url;
+        if (statusNotifier != null) {
+            url = statusNotifier.getUrl();
+        } else {
+            url = config.getUrl();
+        }
+
+        return url + "/" + urlEndPoint;
+    }
+
+    private HttpPost createPostRequest(String url, String data, Map<String, String> headers)
+            throws IOException {
+        HttpPost httpPost = new HttpPost(url);
+        StringEntity entity = new StringEntity(data);
+        httpPost.setEntity(entity);
+        httpPost.setHeader("Accept", "application/json");
+        httpPost.setHeader("Content-type", "application/json");
+        headers.forEach(httpPost::setHeader);
+        return httpPost;
+    }
+
+    private void executePost(HttpPost httpPost) throws IOException {
+        try (CloseableHttpResponse response = client.execute(httpPost)) {
+            int sc = response.getStatusLine().getStatusCode();
+            if (!(sc == HttpStatus.SC_ACCEPTED || sc == HttpStatus.SC_OK)) {
+                throw new ClientProtocolException("Unexpected response status: " + sc);
+            }
+        } finally {
+            httpPost.releaseConnection(); // Release the connection gracefully so the connection can
+            // be reused by connection manager
+        }
+    }
+}

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/StatusNotifier.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/StatusNotifier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+public class StatusNotifier {
+
+    private String url;
+
+    private String endpointTask;
+
+    private String endpointWorkflow;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getEndpointTask() {
+        return endpointTask;
+    }
+
+    public void setEndpointTask(String endpointTask) {
+        this.endpointTask = endpointTask;
+    }
+
+    public String getEndpointWorkflow() {
+        return endpointWorkflow;
+    }
+
+    public void setEndpointWorkflow(String endpointWorkflow) {
+        this.endpointWorkflow = endpointWorkflow;
+    }
+}

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/StatusNotifierNotificationProperties.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/StatusNotifierNotificationProperties.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("conductor.status-notifier.notification")
+public class StatusNotifierNotificationProperties {
+
+    private String url;
+
+    private String endpointTask;
+
+    /*
+     * TBD: list of Task status we are interested in
+     */
+    private List<String> subscribedTaskStatuses;
+
+    private String endpointWorkflow;
+
+    private String headerDomainGroup;
+
+    private String headerAccountCookie;
+
+    private String headerPrefer;
+
+    private String headerPreferValue;
+
+    private int requestTimeOutMsConnect = 100;
+
+    private int requestTimeoutMsread = 300;
+
+    private int requestTimeoutMsConnMgr = 300;
+
+    private int requestRetryCount = 3;
+
+    private int requestRetryCountIntervalMs = 50;
+
+    private int connectionPoolMaxRequest = 3;
+
+    private int connectionPoolMaxRequestPerRoute = 3;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getEndpointTask() {
+        return endpointTask;
+    }
+
+    public void setEndpointTask(String endpointTask) {
+        this.endpointTask = endpointTask;
+    }
+
+    public String getEndpointWorkflow() {
+        return endpointWorkflow;
+    }
+
+    public void setEndpointWorkflow(String endpointWorkflow) {
+        this.endpointWorkflow = endpointWorkflow;
+    }
+
+    public String getHeaderDomainGroup() {
+        return headerDomainGroup;
+    }
+
+    public void setHeaderDomainGroup(String headerDomainGroup) {
+        this.headerDomainGroup = headerDomainGroup;
+    }
+
+    public String getHeaderAccountCookie() {
+        return headerAccountCookie;
+    }
+
+    public void setHeaderAccountCookie(String headerAccountCookie) {
+        this.headerAccountCookie = headerAccountCookie;
+    }
+
+    public String getHeaderPrefer() {
+        return headerPrefer;
+    }
+
+    public void setHeaderPrefer(String headerPrefer) {
+        this.headerPrefer = headerPrefer;
+    }
+
+    public String getHeaderPreferValue() {
+        return headerPreferValue;
+    }
+
+    public void setHeaderPreferValue(String headerPreferValue) {
+        this.headerPreferValue = headerPreferValue;
+    }
+
+    public int getRequestTimeOutMsConnect() {
+        return requestTimeOutMsConnect;
+    }
+
+    public void setRequestTimeOutMsConnect(int requestTimeOutMsConnect) {
+        this.requestTimeOutMsConnect = requestTimeOutMsConnect;
+    }
+
+    public int getRequestTimeoutMsread() {
+        return requestTimeoutMsread;
+    }
+
+    public void setRequestTimeoutMsread(int requestTimeoutMsread) {
+        this.requestTimeoutMsread = requestTimeoutMsread;
+    }
+
+    public int getRequestTimeoutMsConnMgr() {
+        return requestTimeoutMsConnMgr;
+    }
+
+    public void setRequestTimeoutMsConnMgr(int requestTimeoutMsConnMgr) {
+        this.requestTimeoutMsConnMgr = requestTimeoutMsConnMgr;
+    }
+
+    public int getRequestRetryCount() {
+        return requestRetryCount;
+    }
+
+    public void setRequestRetryCount(int requestRetryCount) {
+        this.requestRetryCount = requestRetryCount;
+    }
+
+    public int getRequestRetryCountIntervalMs() {
+        return requestRetryCountIntervalMs;
+    }
+
+    public void setRequestRetryCountIntervalMs(int requestRetryCountIntervalMs) {
+        this.requestRetryCountIntervalMs = requestRetryCountIntervalMs;
+    }
+
+    public int getConnectionPoolMaxRequest() {
+        return connectionPoolMaxRequest;
+    }
+
+    public void setConnectionPoolMaxRequest(int connectionPoolMaxRequest) {
+        this.connectionPoolMaxRequest = connectionPoolMaxRequest;
+    }
+
+    public int getConnectionPoolMaxRequestPerRoute() {
+        return connectionPoolMaxRequestPerRoute;
+    }
+
+    public void setConnectionPoolMaxRequestPerRoute(int connectionPoolMaxRequestPerRoute) {
+        this.connectionPoolMaxRequestPerRoute = connectionPoolMaxRequestPerRoute;
+    }
+
+    public List<String> getSubscribedTaskStatuses() {
+        return subscribedTaskStatuses;
+    }
+
+    public void setSubscribedTaskStatuses(List<String> subscribedTaskStatuses) {
+        this.subscribedTaskStatuses = subscribedTaskStatuses;
+    }
+}

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskNotification.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskNotification.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.run.TaskSummary;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+@JsonFilter("SecretRemovalFilter")
+public class TaskNotification extends TaskSummary {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskStatusPublisher.class);
+
+    public String workflowTaskType;
+
+    /**
+     * Following attributes doesnt exist in TaskSummary so add it here. Not adding in TaskSummary as
+     * it belongs to conductor-common
+     */
+    private String referenceTaskName;
+
+    private int retryCount;
+
+    private String taskDescription;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public String getReferenceTaskName() {
+        return referenceTaskName;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    public String getTaskDescription() {
+        return taskDescription;
+    }
+
+    public TaskNotification(Task task) {
+        super(task);
+
+        referenceTaskName = task.getReferenceTaskName();
+        retryCount = task.getRetryCount();
+        taskDescription = task.getWorkflowTask().getDescription();
+
+        workflowTaskType = task.getWorkflowTask().getType();
+
+        boolean isFusionMetaPresent = task.getInputData().containsKey("_ioMeta");
+        if (!isFusionMetaPresent) {
+            return;
+        }
+    }
+
+    String toJsonString() {
+        String jsonString;
+        SimpleBeanPropertyFilter theFilter =
+                SimpleBeanPropertyFilter.serializeAllExcept("input", "output");
+        FilterProvider provider =
+                new SimpleFilterProvider().addFilter("SecretRemovalFilter", theFilter);
+        try {
+            jsonString = objectMapper.writer(provider).writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to convert Task: {} to String. Exception: {}", this, e);
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+
+    /*
+     * https://github.com/Netflix/conductor/pull/2128
+     * To enable Workflow/Task Summary Input/Output JSON Serialization, use the following:
+     * conductor.app.summary-input-output-json-serialization.enabled=true
+     */
+    String toJsonStringWithInputOutput() {
+        String jsonString;
+        try {
+            SimpleBeanPropertyFilter emptyFilter = SimpleBeanPropertyFilter.serializeAllExcept();
+            FilterProvider provider =
+                    new SimpleFilterProvider().addFilter("SecretRemovalFilter", emptyFilter);
+
+            jsonString = objectMapper.writer(provider).writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to convert Task: {} to String. Exception: {}", this, e);
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+}

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskStatusPublisher.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskStatusPublisher.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.listener.TaskStatusListener;
+import com.netflix.conductor.model.TaskModel;
+
+@Singleton
+public class TaskStatusPublisher implements TaskStatusListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskStatusPublisher.class);
+    private static final Integer QDEPTH =
+            Integer.parseInt(
+                    System.getenv().getOrDefault("ENV_TASK_NOTIFICATION_QUEUE_SIZE", "50"));
+    private BlockingQueue<TaskModel> blockingQueue = new LinkedBlockingDeque<>(QDEPTH);
+
+    private RestClientManager rcm;
+    private ExecutionDAOFacade executionDAOFacade;
+    private List<String> subscribedTaskStatusList;
+
+    class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+        public void uncaughtException(Thread t, Throwable e) {
+            LOGGER.info("An exception has been captured\n");
+            LOGGER.info("Thread: {}\n", t.getName());
+            LOGGER.info("Exception: {}: {}\n", e.getClass().getName(), e.getMessage());
+            LOGGER.info("Stack Trace: \n");
+            e.printStackTrace(System.out);
+            LOGGER.info("Thread status: {}\n", t.getState());
+            new ConsumerThread().start();
+        }
+    }
+
+    class ConsumerThread extends Thread {
+
+        public void run() {
+            this.setUncaughtExceptionHandler(new ExceptionHandler());
+            String tName = Thread.currentThread().getName();
+            LOGGER.info("{}: Starting consumer thread", tName);
+            TaskModel task = null;
+            TaskNotification taskNotification = null;
+            while (true) {
+                try {
+                    task = blockingQueue.take();
+                    taskNotification = new TaskNotification(task.toTask());
+                    String jsonTask = taskNotification.toJsonString();
+                    LOGGER.info("Publishing TaskNotification: {}", jsonTask);
+                    if (taskNotification.getTaskType().equals("SUB_WORKFLOW")) {
+                        LOGGER.info(
+                                "Skip task '{}' notification. Task type is SUB_WORKFLOW.",
+                                taskNotification.getTaskId());
+                        continue;
+                    }
+                    publishTaskNotification(taskNotification);
+                    LOGGER.debug("Task {} publish is successful.", taskNotification.getTaskId());
+                    Thread.sleep(5);
+                } catch (Exception e) {
+                    if (taskNotification != null) {
+                        LOGGER.error(
+                                "Error while publishing task. Hence updating elastic search index taskId {} taskname {}",
+                                task.getTaskId(),
+                                task.getTaskDefName());
+                        // TBD executionDAOFacade.indexTask(task);
+
+                    } else {
+                        LOGGER.error("Failed to publish task: Task is NULL");
+                    }
+                    LOGGER.error("Error on publishing ", e);
+                }
+            }
+        }
+    }
+
+    @Inject
+    public TaskStatusPublisher(
+            RestClientManager rcm,
+            ExecutionDAOFacade executionDAOFacade,
+            List<String> subscribedTaskStatuses) {
+        this.rcm = rcm;
+        this.executionDAOFacade = executionDAOFacade;
+        this.subscribedTaskStatusList = subscribedTaskStatuses;
+        validateSubscribedTaskStatuses(subscribedTaskStatuses);
+        ConsumerThread consumerThread = new ConsumerThread();
+        consumerThread.start();
+    }
+
+    private void validateSubscribedTaskStatuses(List<String> subscribedTaskStatuses) {
+        for (String taskStausType : subscribedTaskStatuses) {
+            if (!taskStausType.equals("SCHEDULED")) {
+                LOGGER.error(
+                        "Task Status Type {} will only push notificaitons when updated through the API. Automatic notifications only work for SCHEDULED type.",
+                        taskStausType);
+            }
+        }
+    }
+
+    private void enqueueTask(TaskModel task) {
+        try {
+            blockingQueue.put(task);
+        } catch (Exception e) {
+            LOGGER.debug(
+                    "Failed to enqueue task: Id {} Type {} of workflow {} ",
+                    task.getTaskId(),
+                    task.getTaskType(),
+                    task.getWorkflowInstanceId());
+            LOGGER.debug(e.toString());
+        }
+    }
+
+    @Override
+    public void onTaskScheduled(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.SCHEDULED.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskCanceled(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.CANCELED.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskCompleted(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.COMPLETED.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskCompletedWithErrors(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.COMPLETED_WITH_ERRORS.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskFailed(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.FAILED.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskFailedWithTerminalError(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskInProgress(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.IN_PROGRESS.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskSkipped(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.SKIPPED.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    @Override
+    public void onTaskTimedOut(TaskModel task) {
+        if (subscribedTaskStatusList.contains(TaskModel.Status.TIMED_OUT.name())) {
+            enqueueTask(task);
+        }
+    }
+
+    private void publishTaskNotification(TaskNotification taskNotification) throws IOException {
+        String jsonTask = taskNotification.toJsonStringWithInputOutput();
+        rcm.postNotification(
+                RestClientManager.NotificationType.TASK,
+                jsonTask,
+                taskNotification.getTaskId(),
+                null);
+    }
+}

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskStatusPublisherConfiguration.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskStatusPublisherConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.listener.TaskStatusListener;
+
+@Configuration
+@EnableConfigurationProperties(StatusNotifierNotificationProperties.class)
+@ConditionalOnProperty(name = "conductor.task-status-listener.type", havingValue = "task_publisher")
+public class TaskStatusPublisherConfiguration {
+
+    @Bean
+    public TaskStatusListener getTaskStatusListener(
+            RestClientManager rcm,
+            ExecutionDAOFacade executionDAOFacade,
+            StatusNotifierNotificationProperties config) {
+
+        return new TaskStatusPublisher(rcm, executionDAOFacade, config.getSubscribedTaskStatuses());
+    }
+}

--- a/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/statuschange/StatusChangeNotification.java
+++ b/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/statuschange/StatusChangeNotification.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener.statuschange;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.contribs.listener.StatusNotifier;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+@JsonFilter("SecretRemovalFilter")
+class StatusChangeNotification extends WorkflowSummary {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatusChangePublisher.class);
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private StatusNotifier statusNotifier;
+
+    StatusChangeNotification(Workflow workflow) {
+        super(workflow);
+        Map<String, Object> variables = workflow.getVariables();
+        Object statusNotifierVariable = variables.get("statusNotifier");
+        if (statusNotifier != null) {
+            try {
+                statusNotifier =
+                        objectMapper.readValue(
+                                statusNotifierVariable.toString(), new TypeReference<>() {});
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public StatusNotifier getStatusNotifier() {
+        return statusNotifier;
+    }
+
+    String toJsonString() {
+        String jsonString;
+        try {
+            SimpleBeanPropertyFilter theFilter =
+                    SimpleBeanPropertyFilter.serializeAllExcept("input", "output");
+            FilterProvider provider =
+                    new SimpleFilterProvider().addFilter("SecretRemovalFilter", theFilter);
+            jsonString = objectMapper.writer(provider).writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "Failed to convert workflow {} id: {} to String. Exception: {}",
+                    this.getWorkflowType(),
+                    this.getWorkflowId(),
+                    e);
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+
+    /*
+     * https://github.com/Netflix/conductor/pull/2128
+     * To enable Workflow/Task Summary Input/Output JSON Serialization, use the following:
+     * conductor.app.summary-input-output-json-serialization.enabled=true
+     */
+    String toJsonStringWithInputOutput() {
+        String jsonString;
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            SimpleBeanPropertyFilter emptyFilter = SimpleBeanPropertyFilter.serializeAllExcept();
+            FilterProvider provider =
+                    new SimpleFilterProvider().addFilter("SecretRemovalFilter", emptyFilter);
+            jsonString = objectMapper.writer(provider).writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "Failed to convert workflow {} id: {} to String. Exception: {}",
+                    this.getWorkflowType(),
+                    this.getWorkflowId(),
+                    e);
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+}

--- a/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/statuschange/StatusChangePublisher.java
+++ b/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/statuschange/StatusChangePublisher.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener.statuschange;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.contribs.listener.RestClientManager;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.listener.WorkflowStatusListener;
+import com.netflix.conductor.model.WorkflowModel;
+
+@Singleton
+public class StatusChangePublisher implements WorkflowStatusListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatusChangePublisher.class);
+    private static final Integer QDEPTH =
+            Integer.parseInt(
+                    System.getenv().getOrDefault("ENV_WORKFLOW_NOTIFICATION_QUEUE_SIZE", "50"));
+    private BlockingQueue<WorkflowModel> blockingQueue = new LinkedBlockingDeque<>(QDEPTH);
+    private RestClientManager rcm;
+    private ExecutionDAOFacade executionDAOFacade;
+
+    class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+        public void uncaughtException(Thread t, Throwable e) {
+            LOGGER.info("An exception has been captured\n");
+            LOGGER.info("Thread: {}\n", t.getName());
+            LOGGER.info("Exception: {}: {}\n", e.getClass().getName(), e.getMessage());
+            LOGGER.info("Stack Trace: \n");
+            e.printStackTrace(System.out);
+            LOGGER.info("Thread status: {}\n", t.getState());
+            new ConsumerThread().start();
+        }
+    }
+
+    class ConsumerThread extends Thread {
+
+        public void run() {
+            this.setUncaughtExceptionHandler(new ExceptionHandler());
+            String tName = Thread.currentThread().getName();
+            LOGGER.info("{}: Starting consumer thread", tName);
+
+            StatusChangeNotification statusChangeNotification = null;
+            WorkflowModel workflow = null;
+            while (true) {
+                try {
+                    workflow = blockingQueue.take();
+                    statusChangeNotification = new StatusChangeNotification(workflow.toWorkflow());
+                    String jsonWorkflow = statusChangeNotification.toJsonString();
+                    LOGGER.info("Publishing StatusChangeNotification: {}", jsonWorkflow);
+                    publishStatusChangeNotification(statusChangeNotification);
+                    LOGGER.debug(
+                            "Workflow {} publish is successful.",
+                            statusChangeNotification.getWorkflowId());
+                    Thread.sleep(5);
+                } catch (Exception e) {
+                    if (statusChangeNotification != null) {
+                        LOGGER.error(
+                                " Error while publishing workflow. Hence updating elastic search index workflowid {} workflowname {} correlationId {}",
+                                workflow.getWorkflowId(),
+                                workflow.getWorkflowName(),
+                                workflow.getCorrelationId());
+                        // TBD executionDAOFacade.indexWorkflow(workflow);
+                    } else {
+                        LOGGER.error("Failed to publish workflow: Workflow is NULL");
+                    }
+                    LOGGER.error("Error on publishing workflow", e);
+                }
+            }
+        }
+    }
+
+    @Inject
+    public StatusChangePublisher(RestClientManager rcm, ExecutionDAOFacade executionDAOFacade) {
+        this.rcm = rcm;
+        this.executionDAOFacade = executionDAOFacade;
+        ConsumerThread consumerThread = new ConsumerThread();
+        consumerThread.start();
+    }
+
+    @Override
+    public void onWorkflowCompleted(WorkflowModel workflow) {
+        LOGGER.debug(
+                "workflows completion {} {}", workflow.getWorkflowId(), workflow.getWorkflowName());
+        try {
+            blockingQueue.put(workflow);
+        } catch (Exception e) {
+            LOGGER.error(
+                    "Failed to enqueue workflow: Id {} Name {}",
+                    workflow.getWorkflowId(),
+                    workflow.getWorkflowName());
+            LOGGER.error(e.toString());
+        }
+    }
+
+    @Override
+    public void onWorkflowTerminated(WorkflowModel workflow) {
+        LOGGER.debug(
+                "workflows termination {} {}",
+                workflow.getWorkflowId(),
+                workflow.getWorkflowName());
+        try {
+            blockingQueue.put(workflow);
+        } catch (Exception e) {
+            LOGGER.error(
+                    "Failed to enqueue workflow: Id {} Name {}",
+                    workflow.getWorkflowId(),
+                    workflow.getWorkflowName());
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public void onWorkflowCompletedIfEnabled(WorkflowModel workflow) {
+        onWorkflowCompleted(workflow);
+    }
+
+    @Override
+    public void onWorkflowTerminatedIfEnabled(WorkflowModel workflow) {
+        onWorkflowTerminated(workflow);
+    }
+
+    private void publishStatusChangeNotification(StatusChangeNotification statusChangeNotification)
+            throws IOException {
+        String jsonWorkflow = statusChangeNotification.toJsonStringWithInputOutput();
+        rcm.postNotification(
+                RestClientManager.NotificationType.WORKFLOW,
+                jsonWorkflow,
+                statusChangeNotification.getWorkflowId(),
+                statusChangeNotification.getStatusNotifier());
+    }
+}

--- a/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/statuschange/StatusChangePublisherConfiguration.java
+++ b/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/statuschange/StatusChangePublisherConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener.statuschange;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.conductor.contribs.listener.RestClientManager;
+import com.netflix.conductor.contribs.listener.StatusNotifierNotificationProperties;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.listener.WorkflowStatusListener;
+
+@Configuration
+@EnableConfigurationProperties(StatusNotifierNotificationProperties.class)
+@ConditionalOnProperty(
+        name = "conductor.workflow-status-listener.type",
+        havingValue = "workflow_publisher")
+public class StatusChangePublisherConfiguration {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(StatusChangePublisherConfiguration.class);
+
+    @Bean
+    public RestClientManager getRestClientManager(StatusNotifierNotificationProperties config) {
+        return new RestClientManager(config);
+    }
+
+    @Bean
+    public WorkflowStatusListener getWorkflowStatusListener(
+            RestClientManager restClientManager, ExecutionDAOFacade executionDAOFacade) {
+
+        return new StatusChangePublisher(restClientManager, executionDAOFacade);
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue Netflix / conductor-community#212
We require a notification published from Conductor to a callback URL when certain task statuses are reached.

This continues the changes proposed by @\charybr in Netflix / conductor-community#228, which originates from the changes made by @\techyragu in CiscoM31 / conductor#26.

We have added functionally to allow the user to specify a URL to send task and workflow statuses to respectively. The url can be specified in the configuration file used when the user’s specific conductor instance is being spun up. Below is an example of the properties added to the config:

```
conductor.status-notifier.notification.url=http://example.com
conductor.status-notifier.notification.endpointTask=
conductor.status-notifier.notification.endpointWorkflow=
conductor.status-notifier.notification.subscribedTaskStatuses=SCHEDULED
```

The endpointTask property is where task notifications will be sent. The endpointWorkflow property is where workflow notifications will be sent. The subscribedTaskStatuses property should be set to SCHEDULED as that is the only state change currently being listened for, but this implementation allows for future enhancements to be added for other task notification types to be listened for and specified in this property to be received at the endpointTask endpoint.

The information that will be sent in a task notification is shown in the following example:

<details>
<summary>Expand</summary>

```json
"data": {
	"correlationId": null,
	"domain": null,
	"endTime": "1970-01-01T00:00:00.000Z",
	"executionTime": 0,
	"externalInputPayloadStoragePath": null,
	"externalOutputPayloadStoragePath": null,
	"input": "{\"asyncComplete\":false,\"http_request\":{\"method\":\"GET\",\"uri\":\"https://datausa.io/api/data?drilldowns=Nation&measures=Population\"}}",
	"output": "{}",
	"queueWaitTime": 31,
	"reasonForIncompletion": null,
	"referenceTaskName": "get_population_data",
	"retryCount": 0,
	"scheduledTime": "2024-04-01T22:21:19.112Z",
	"startTime": "2024-04-01T22:21:19.143Z",
	"status": "SCHEDULED",
	"taskDefName": "get_population_data",
	"taskDescription": null,
	"taskId": "4dea6f89-df79-4b6e-8952-96728e061885",
	"taskType": "HTTP",
	"updateTime": "1970-01-01T00:00:00.000Z",
	"workflowId": "b3e5c928-3d26-4f79-bf41-9a02c9d96239",
	"workflowPriority": 0,
	"workflowTaskType": "HTTP",
	"workflowType": "testwf"
}
```

</details>

Whenever a workflow is completed, a notification will be sent out to the specified webhook. The information that will be sent in a workflow notification is shown in the following example:

<details>
<summary>Expand</summary>

```json
"data": {
	"correlationId": null,
	"endTime": "2024-04-01T22:21:21.443Z",
	"event": null,
	"executionTime": 3419,
	"externalInputPayloadStoragePath": null,
	"externalOutputPayloadStoragePath": null,
	"failedReferenceTaskNames": "",
	"failedTaskNames": [],
	"input": "{}",
	"inputSize": 2,
	"output": "{\"data\":[{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2021,\"Year\":\"2021\",\"Population\":329725481,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2020,\"Year\":\"2020\",\"Population\":326569308,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2019,\"Year\":\"2019\",\"Population\":324697795,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2018,\"Year\":\"2018\",\"Population\":322903030,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2017,\"Year\":\"2017\",\"Population\":321004407,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2016,\"Year\":\"2016\",\"Population\":318558162,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2015,\"Year\":\"2015\",\"Population\":316515021,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2014,\"Year\":\"2014\",\"Population\":314107084,\"Slug Nation\":\"united-states\"},{\"ID Nation\":\"01000US\",\"Nation\":\"United States\",\"ID Year\":2013,\"Year\":\"2013\",\"Population\":311536594,\"Slug Nation\":\"united-states\"}],\"source\":[{\"measures\":[\"Population\"],\"annotations\":{\"source_name\":\"Census Bureau\",\"source_description\":\"The American Community Survey (ACS) is conducted by the US Census and sent to a portion of the population every year.\",\"dataset_name\":\"ACS 5-year Estimate\",\"dataset_link\":\"http://www.census.gov/programs-surveys/acs/\",\"table_id\":\"B01003\",\"topic\":\"Diversity\",\"subtopic\":\"Demographics\"},\"name\":\"acs_yg_total_population_5\",\"substitutions\":[]}]}",
	"outputSize": 1633,
	"priority": 0,
	"reasonForIncompletion": null,
	"startTime": "2024-04-01T22:21:18.024Z",
	"status": "COMPLETED",
	"statusNotifier": null,
	"updateTime": "2024-04-01T22:21:21.443Z",
	"version": 1,
	"workflowId": "b3e5c928-3d26-4f79-bf41-9a02c9d96239",
	"workflowType": "testwf"
}
```

</details>

This functionality is needed to efficiently process requests when workflows are being managed through a 3rd party service. This functionality is also useful to ascertain which tasks commonly fail, and where a long workflow is in execution at any given time.

Alternatives considered
----

_Describe alternative implementation you have considered_
An alternative to pushing webhook notifications would be client applications pulling a workflow or task status from Conductor. This approach does not scale if hundreds or thousands of workflows need to be monitored, calling upon each status of which would become a very expensive operation.

----
Authors @\BabyBlue0214 @\EJ-S @\ToastedTaco @\CollinDewey
